### PR TITLE
added support for keyd virtual keyboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@
 
 [Framework]: https://frame.work/
 
-This is a fork of the original `keylightd` to make it compatible with systems that use [keyd].
+This is a fork of the original `keylightd` to make it compatible with systems that use [keyd] or [kanata].
 
 [keyd]: https://github.com/rvaiya/keyd
+[kanata]: https://github.com/jtroo/kanata
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@
 
 [Framework]: https://frame.work/
 
+This is a fork of the original `keylightd` to make it compatible with systems that use [keyd].
+
+[keyd]: https://github.com/rvaiya/keyd
+
 ## Installation
 
 To install from source, clone the repository and run:

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,7 +99,7 @@ fn main() -> anyhow::Result<()> {
         // Filter devices so that only the Framework's builtin touchpad and keyboard are listened
         // to. Since we don't support hotplug, listening on USB devices wouldn't work reliably.
         match device.name() {
-            Some("PIXA3854:00 093A:0274 Touchpad" | "AT Translated Set 2 keyboard") => {
+            Some("PIXA3854:00 093A:0274 Touchpad" | "AT Translated Set 2 keyboard" | "keyd virtual keyboard" ) => {
                 let act = act.clone();
                 thread::spawn(move || -> io::Result<()> {
                     let name = device.name();


### PR DESCRIPTION
Minor enhancement to also detect the virtual input device created by the keyd service. Without this modification, keylightd does not work on Framework laptop together with keyd.