### PR TITLE
Fix non-binding let breaking build

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -131,7 +131,7 @@ fn main() -> anyhow::Result<()> {
     loop {
         let guard = act.last_activity.lock().unwrap();
         let last = *guard;
-        let (_, result) = act
+        let (_unused, result) = act
             .condvar
             .wait_timeout_while(guard, Duration::from_secs(args.timeout.into()), |instant| {
                 *instant == last


### PR DESCRIPTION
```
$ cargo build --release
   Compiling keylightd v1.1.0 (/home/caocoa/Dropbox/Pierre/src/github.com/jonas-schievink/keylightd)
error: non-binding let on a synchronization lock
   --> src/main.rs:134:14
    |
134 |         let (_, result) = act
    |              ^ this lock is not assigned to a binding and is immediately dropped
    |
    = help: consider immediately dropping the value using `drop(..)` after the `let` statement
    = note: `#[deny(let_underscore_lock)]` on by default
help: consider binding to an unused variable to avoid immediately dropping the value
    |
134 |         let (_unused, result) = act
    |              ~~~~~~~

error: could not compile `keylightd` (bin "keylightd") due to 1 previous error
```